### PR TITLE
Supports card endpoints changing due to multiple dashboards

### DIFF
--- a/src/mixins/HasCards.js
+++ b/src/mixins/HasCards.js
@@ -17,6 +17,12 @@ export default {
     this.fetchCards()
   },
 
+  watch: {
+    cardsEndpoint() {
+      this.fetchCards()
+    }
+  },
+
   methods: {
     async fetchCards() {
       // We disable fetching of cards when the component is being show


### PR DESCRIPTION
This is a change that will allow multiple custom dashboards to be made.

Currently, the Dashboard component only fires `fetchCards` on `created`, but due to how the routing happens, if you have multiple different instances of the Dashboard component, it will not get re-created, but instead will just have its props changed.

The prop that changes is now being watched, and when it changes, it fires the `fetchCards` API call.