### PR TITLE
Don't replace every falsy field value with an empty string

### DIFF
--- a/src/mixins/FormField.js
+++ b/src/mixins/FormField.js
@@ -29,7 +29,7 @@ export default {
      * Set the initial value for the field
      */
     setInitialValue() {
-      this.value = this.field.value || ''
+      this.value = !(this.field.value === undefined || this.field.value === null) ? this.field.value : ''
     },
 
     /**


### PR DESCRIPTION
Not sure if this repo even accepts PRs, but this fixes https://github.com/laravel/nova-issues/issues/500.

Instead of replacing everything that evaluates to `false` with an empty string, only `undefined` and `null` are replaced. Other falsy values (such as `0`) are kept as-is.