### PR TITLE
Dellocate default result per page to respect first per page options

### DIFF
--- a/src/mixins/PerPageable.js
+++ b/src/mixins/PerPageable.js
@@ -1,5 +1,5 @@
 export default {
-  data: () => ({ perPage: 25 }),
+  data: () => ({ perPage: null }),
 
   methods: {
     /**
@@ -22,7 +22,7 @@ export default {
      * Get the current per page value from the query string.
      */
     currentPerPage() {
-      return this.$route.query[this.perPageParameter] || 25
+      return this.$route.query[this.perPageParameter] || null
     },
   },
 }


### PR DESCRIPTION
nova-api will bring the first amount of resources per page if it is not through a relationship, in case the user filters by an amount it will prevail.