### PR TITLE
Don't pluralise string if string ends with non alphanumeric character.

### DIFF
--- a/src/util/singularOrPlural.js
+++ b/src/util/singularOrPlural.js
@@ -1,7 +1,7 @@
 import { Inflector } from '../'
 
 export default function singularOrPlural(value, suffix) {
-    if (value.match(/^(.*)[A-Za-z]$/) == null) return value
+    if (value.match(/^(.*)[A-Za-zÀ-ÖØ-öø-ÿ]$/) == null) return value
     else if (value > 1 || value == 0) return Inflector.pluralize(suffix)
     return Inflector.singularize(suffix)
 }

--- a/src/util/singularOrPlural.js
+++ b/src/util/singularOrPlural.js
@@ -1,6 +1,7 @@
 import { Inflector } from '../'
 
 export default function singularOrPlural(value, suffix) {
-    if (value > 1 || value == 0) return Inflector.pluralize(suffix)
+    if (value.match(/^(.*)[A-Za-z]$/) == null) return value
+    else if (value > 1 || value == 0) return Inflector.pluralize(suffix)
     return Inflector.singularize(suffix)
 }


### PR DESCRIPTION
Fixes laravel/nova-issues#696

e.g:`50%` should return `50%` and not `50%s`

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>