### PR TITLE
Use export default on mapProps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ import { Errors } from 'form-backend-validation'
 import SingularOrPlural from './util/singularOrPlural'
 
 // PropTypes
-import { mapProps } from './propTypes'
+import mapProps from './propTypes'
 
 export {
   // Mixins

--- a/src/mixins/FormField.js
+++ b/src/mixins/FormField.js
@@ -1,4 +1,4 @@
-import { mapProps } from '../propTypes'
+import mapProps from '../propTypes'
 
 export default {
   props: mapProps([

--- a/src/propTypes/index.js
+++ b/src/propTypes/index.js
@@ -41,8 +41,6 @@ const propTypes = {
   },
 }
 
-function mapProps(attributes) {
+export default function mapProps(attributes) {
   return _.pick(propTypes, attributes)
 }
-
-export { mapProps }


### PR DESCRIPTION
v1.10.0 missing `mapProps` from `dist/index.js` generated from npm.org

https://runkit.com/embed/i1v9rxiwfyfq

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>