### PR TITLE
Use npm prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "laravel-nova",
   "version": "1.12.1",
   "description": "Supporting modules for Laravel Nova",
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "scripts": {
     "start": "NODE_ENV=production webpack --watch --config webpack.config.js",
     "demo": "NODE_ENV=production webpack --config webpack.config.js",
     "build": "rm -rf dist && NODE_ENV=production webpack",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "test": "jest"
   },
   "repository": {


### PR DESCRIPTION
As of npm 4, npm prepublish has been deprecated, see https://docs.npmjs.com/cli/v7/using-npm/scripts/#prepare-and-prepublish

Original issue: https://github.com/npm/npm/issues/10074

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>